### PR TITLE
Decrement positive sensor count by 1

### DIFF
--- a/custom_components/wyzesense/wyzesense_custom.py
+++ b/custom_components/wyzesense/wyzesense_custom.py
@@ -462,6 +462,9 @@ class Dongle(object):
         assert len(resp.Payload) == 1
         count = resp.Payload[0]
 
+        if count > 0:
+            count -= 1   # Decrease the sensor count by one
+
         ctx = self.CmdContext(count=count, index=0, sensors=[])
         if count > 0:
             log.debug("%d sensors reported, waiting for each one to report...", count)


### PR DESCRIPTION
It seems as though the bridge responds with a sensor count that is one higher than the actual number of sensors when any sensors are paired. If no sensors are paired, it responds with 0. Decrement the positive sensor count by 1 so we don't wait around until the timeout value is reached for the n+1'th non-existent sensor MAC to come back. If you have more than ~12 sensors paired, the total timeout value exceeds 60 seconds, and causes Home Assistant to time out and move on without wyzesense, thus no wyzesense.scan or wyzesense.remove services show up.